### PR TITLE
Support Mac (first step) by use brew

### DIFF
--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -1,4 +1,13 @@
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-sudo apt-get update
-sudo apt-get install -y cmake git build-essential libssl-dev libgmp-dev python libboost-all-dev
+if [ "$(uname)" == "Darwin" ]; then
+	brew update
+	brew install openssl
+	brew install xctool
+	brew install cmake
+	brew install gmp
+	brew install boost
+else
+	sudo apt-get install -y software-properties-common
+	sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
+	sudo apt-get update
+	sudo apt-get install -y cmake git build-essential libssl-dev libgmp-dev python libboost-all-dev
+fi


### PR DESCRIPTION
This is the first one of the whole series of updates to support Mac. 

I am now working on simplifying the update for `emp-tool` and make it more stable in finding `OpenSSL`. It has passed the test in Circle-CI, which supports AES.

(Mac disables OpenSSL to be in /usr/local/bin because they prefer their own one. Therefore, specified linking is needed to add OpenSSL. The current version of `cmake` does not work to enhance their `FindOpenSSL` for Mac)