### PR TITLE
Add note for Mac developers and `brew list xxx ||`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Note that preset options for relic is for efficient ECC operations.
 
 3. Install tools. Instruction can be found in the repo, or can be found [here](https://github.com/emp-toolkit/emp-readme/tree/master/scripts)
 
+## Note for Mac Developers
+
+1. Use Homebrew to install OpenSSL first. `brew install openssl`.
+
+2. Specify `OPENSSL_ROOT_DIR` before installation, e.g., `export OPENSSL_ROOT_DIR=/usr/local/opt/openssl`. The root path can be found by `brew info openssl`.
+
 ## Documentation (under development)
 
 https://emp-toolkit.github.io/emp-doc/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Detailed Installation
 
-1. Install related packages including `cmake git build-essential libssl-dev libgmp-dev`, or use this [script](https://github.com/emp-toolkit/emp-readme/blob/master/scripts/install_packages.sh).
+1. Install related packages including `cmake git build-essential libssl-dev libgmp-dev` (for Linux), or `openssl xctool pkg-config cmake gmp boost` (for Mac), or use this [script](https://github.com/emp-toolkit/emp-readme/blob/master/scripts/install_packages.sh).
 
 2. Install [relic-toolkit](https://github.com/relic-toolkit/relic), or use this [script](https://github.com/emp-toolkit/emp-readme/blob/master/scripts/install_relic.sh).
 Note that preset options for relic is for efficient ECC operations.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that preset options for relic is for efficient ECC operations.
 
 1. Use Homebrew to install OpenSSL first. `brew install openssl`.
 
-2. Specify `OPENSSL_ROOT_DIR` before installation, e.g., `export OPENSSL_ROOT_DIR=/usr/local/opt/openssl`. The root path can be found by `brew info openssl`.
+2. Add the pkgconfig file of OpenSSL to `PKG_CONFIG_PATH`, e.g., `export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/openssl/lib/pkgconfig`. The pkg-config path can be found by `brew info openssl`.
 
 ## Documentation (under development)
 

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -2,6 +2,7 @@ if [ "$(uname)" == "Darwin" ]; then
 	brew update
 	brew list openssl || brew install openssl
 	brew list xctool || brew install xctool
+	brew list pkg-config || brew install pkg-config
 	brew list cmake || brew install cmake
 	brew list gmp || brew install gmp
 	brew list boost || brew install boost

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -1,10 +1,10 @@
 if [ "$(uname)" == "Darwin" ]; then
 	brew update
-	brew install openssl
-	brew install xctool
-	brew install cmake
-	brew install gmp
-	brew install boost
+	brew list openssl || brew install openssl
+	brew list xctool || brew install xctool
+	brew list cmake || brew install cmake
+	brew list gmp || brew install gmp
+	brew list boost || brew install boost
 else
 	sudo apt-get install -y software-properties-common
 	sudo add-apt-repository -y ppa:george-edison55/cmake-3.x


### PR DESCRIPTION
I think one solution to end Mac-OpenSSL story is to add a note.

Also, I add `pkg-config` which would be a better way to include OpenSSL, it passed Circle CI.
And, use `brew list xxx || brew install xxx` style.

Note that the `note` is a suggestion. Feel free to change it.