### PR TITLE
Candidate PR for package installation script

### DIFF
--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -8,10 +8,8 @@ if [ "$(uname)" == "Darwin" ]; then
 	brew list boost || brew install boost
 else
 	sudo apt-get install -y software-properties-common
-	sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-	sudo add-apt-repository -y ppa:kojoley/boost
 	sudo apt-get update
 	sudo apt-get install -y cmake git build-essential libssl-dev libgmp-dev python 
-	sudo apt-get install -y libboost1.58-dev
-	sudo apt-get install -y libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}1.58-dev
+	sudo apt-get install -y libboost-dev
+	sudo apt-get install -y libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}-dev
 fi


### PR DESCRIPTION
The corresponding issue is #5.

Basically, the use of ppa makes emp-toolkit installation in newer versions of Ubuntu fail because ppa is outdated and does not have versions for newer systems.

However, actually, in many newer versions, we have the required versions of libboost and cmake.

This candidate PR just removes the use of ppa and welcomes new versions of libboost. 